### PR TITLE
DM-38460: Grid proxy error when running cm check

### DIFF
--- a/examples/common_setup.sh
+++ b/examples/common_setup.sh
@@ -19,9 +19,5 @@ export PANDA_AUTH=oidc
 export PANDA_VERIFY_HOST=off
 export PANDA_AUTH_VO=Rubin
 
-# IDDS_CONFIG path depends on the weekly version
-export PANDA_SYS=$CONDA_PREFIX
-export IDDS_CONFIG=${PANDA_SYS}/etc/idds/idds.cfg.client.template
-
 # WMS plugin
 export BPS_WMS_SERVICE_CLASS=lsst.ctrl.bps.panda.PanDAService

--- a/examples/common_setup.sh
+++ b/examples/common_setup.sh
@@ -21,3 +21,7 @@ export PANDA_AUTH_VO=Rubin
 
 # WMS plugin
 export BPS_WMS_SERVICE_CLASS=lsst.ctrl.bps.panda.PanDAService
+
+# Using pandaclient instead of sdfproxy
+export no_proxy=.slac.stanford.edu,.cern.ch
+export NO_PROXY=.slac.stanford.edu,.cern.ch

--- a/examples/common_setup.sh
+++ b/examples/common_setup.sh
@@ -8,4 +8,20 @@ export CM_PROD_DIR="${EXAMPLES}"
 export CM_PROD_URL="output/archive"
 export CM_BUTLER="${butler_repo}"
 export CM_SCRIPT_METHOD="slurm"
+
+# Setting panda variables
+export PANDA_CONFIG_ROOT=$HOME/.panda
+export PANDA_URL_SSL=https://pandaserver-doma.cern.ch:25443/server/panda
+export PANDA_URL=http://pandaserver-doma.cern.ch:25080/server/panda
+export PANDACACHE_URL=$PANDA_URL_SSL
 export PANDAMON_URL=https://panda-doma.cern.ch
+export PANDA_AUTH=oidc
+export PANDA_VERIFY_HOST=off
+export PANDA_AUTH_VO=Rubin
+
+# IDDS_CONFIG path depends on the weekly version
+export PANDA_SYS=$CONDA_PREFIX
+export IDDS_CONFIG=${PANDA_SYS}/etc/idds/idds.cfg.client.template
+
+# WMS plugin
+export BPS_WMS_SERVICE_CLASS=lsst.ctrl.bps.panda.PanDAService


### PR DESCRIPTION
Previously, we set our panda environment variables only when jobs were run. We need this to happen in the setup file also. Small bug fix that should get merged to main so we can use error checking.