### PR TITLE
DM-38559: Usability changes to cm_prod

### DIFF
--- a/examples/script_hsc_rc2_subset.sh
+++ b/examples/script_hsc_rc2_subset.sh
@@ -4,6 +4,12 @@ EXAMPLES="$(dirname -- "$(readlink -f -- "$0";)";)"
 
 source $EXAMPLES/examples/hsc_rc2_subset_setup.sh
 
+read -p "This script will blow away the cm database and start a fresh one based on your setup file. Are you sure you want to do this? (y/N)" $ANSWER
+if [[$ANSWER!='y']] && [[$ANSWER!='yes']] && [[$ANSWER!='Y']] && [[$ANSWER!='Yes']] && [[$ANSWER!='YES']]; then
+    echo "The environment variables for your production were already sourced. You may proceed to your usual cm business without panic."
+    exit 1
+fi
+
 \rm -rf $CM_PROD_URL/$fullname $db_path
 mkdir -p output
 

--- a/examples/script_hsc_rc2_subset.sh
+++ b/examples/script_hsc_rc2_subset.sh
@@ -4,17 +4,34 @@ EXAMPLES="$(dirname -- "$(readlink -f -- "$0";)";)"
 
 source $EXAMPLES/examples/hsc_rc2_subset_setup.sh
 
-read -p "This script will blow away the cm database and start a fresh one based on your setup file. Are you sure you want to do this? (y/N)" $ANSWER
-if [[$ANSWER!='y']] && [[$ANSWER!='yes']] && [[$ANSWER!='Y']] && [[$ANSWER!='Yes']] && [[$ANSWER!='YES']]; then
-    echo "The environment variables for your production were already sourced. You may proceed to your usual cm business without panic."
-    exit 1
+default=no
+read -p "This script will blow away the cm database and start a fresh one based on your setup file. Are you sure you want to do this? (y/N)" ANSWER
+ANSWER=${ANSWER:-$default}
+
+yeses="y Y yes Yes YES yEs yES yeS"
+blow_away=false
+for yes in $yeses; do
+    if [ $yes = $ANSWER ]
+    then
+	    blow_away=true
+	    break
+    else
+	    continue
+    fi
+done
+
+echo "Your environment variables have already been set up."
+if $blow_away
+then
+    echo "Enjoy your fresh cm database!"
+    \rm -rf $CM_PROD_URL/$fullname $db_path
+    mkdir -p output
+
+    cm create
+    cm parse --config-name ${config_name} --config-yaml ${config}
+    cm insert --production-name ${p_name}
+    cm insert --production-name ${p_name} --campaign-name ${c_name} --butler-repo ${butler_repo} --config-name ${config_name} --config-block campaign --lsst-version ${lsst_version} --root-coll ${root_coll}
+    cm daemon --fullname ${fullname} --max-running 0
+else
+    echo "We did not delete your cm database. You may proceed to your usual cm business without panic."
 fi
-
-\rm -rf $CM_PROD_URL/$fullname $db_path
-mkdir -p output
-
-cm create
-cm parse --config-name ${config_name} --config-yaml ${config}
-cm insert --production-name ${p_name}
-cm insert --production-name ${p_name} --campaign-name ${c_name} --butler-repo ${butler_repo} --config-name ${config_name} --config-block campaign --lsst-version ${lsst_version} --root-coll ${root_coll}
-cm daemon --fullname ${fullname} --max-running 0

--- a/examples/script_hsc_weekly.sh
+++ b/examples/script_hsc_weekly.sh
@@ -4,11 +4,34 @@ EXAMPLES="$(dirname -- "$(readlink -f -- "$0";)";)"
 
 source $EXAMPLES/examples/hsc_weekly_setup.sh
 
-\rm -rf $CM_PROD_URL/$fullname $db_path
-mkdir -p output
+default=no
+read -p "This script will blow away the cm database and start a fresh one based on your setup file. Are you sure you want to do this? (y/N)" ANSWER
+ANSWER=${ANSWER:-$default}
 
-cm create
-cm parse --config-name ${config_name} --config-yaml ${config}
-cm insert --production-name ${p_name}
-cm insert --production-name ${p_name} --campaign-name ${c_name} --butler-repo ${butler_repo} --config-name ${config_name} --config-block campaign --lsst-version ${lsst_version} --root-coll ${root_coll}
-cm daemon --fullname ${fullname} --max-running 0
+yeses="y Y yes Yes YES yEs yES yeS"
+blow_away=false
+for yes in $yeses; do
+    if [ $yes = $ANSWER ]
+    then
+	    blow_away=true
+	    break
+    else
+	    continue
+    fi
+done
+
+echo "Your environment variables have already been set up."
+if $blow_away
+then
+    echo "Enjoy your fresh cm database!"
+    \rm -rf $CM_PROD_URL/$fullname $db_path
+    mkdir -p output
+
+    cm create
+    cm parse --config-name ${config_name} --config-yaml ${config}
+    cm insert --production-name ${p_name}
+    cm insert --production-name ${p_name} --campaign-name ${c_name} --butler-repo ${butler_repo} --config-name ${config_name} --config-block campaign --lsst-version ${lsst_version} --root-coll ${root_coll}
+    cm daemon --fullname ${fullname} --max-running 0
+else
+    echo "We did not delete your cm database. You may proceed to your usual cm business without panic."
+fi


### PR DESCRIPTION
This pull request concerns failsafes which prevent users from blowing away the database by accident. More modifications regarding these are on the ticket, although given where I've put the cm commands I'm not sure they'll work the same way so I wanted to request review both to pull these changes into main and also to ask about the additional ones on the ticket. From discussions on the ticket, we should cover:

1. It is too easy to blow away everything. When sourcing campaign setup scripts, prompt the user before running anything.
2. When blowing away the database, also delete the submit directory.
3. Put in a line for `custom_lsst_setup: ""` in an example setup in main.
4.  butler remove-collections on the collections created by examples/scripts, but we must not actually remove data (ie, avoid remove-runs)

This pull request covers point 1. I will continue to work on 2-4 on this ticket, but wanted to pull these changes into main as soon as possible.