### PR TITLE
DM-38620: Regex evaluates "Failed to execute payload" to match the shortest error message which begins in this way, causing incorrect error reporting

### DIFF
--- a/examples/error_code_decisions.yaml
+++ b/examples/error_code_decisions.yaml
@@ -88,14 +88,6 @@ pandaErrorCode:
             rescue: False
             flavor: "pipelines"
             intensity: 0
-        vague_finalizeCharacterization:
-            diagMessage: "Failed to execute payload"
-            pipetask: finalizeCharacterization
-            ticket: ["DM-36066"]
-            resolved: True
-            rescue: True
-            flavor: "panda"
-            intensity: 0
         do_compute_kernel_image:
             diagMessage: >
                 File \"src/CoaddPsf.cc\", line 254, in virtual std:shared_ptr > lsst:meas:algorithms:


### PR DESCRIPTION
Most edits for this ticket were done when the file was in cm_tools, but this last detail was important. The deleted error occurred once during a PanDA failure and was causing more problems than it was worth to have recorded. 