### PR TITLE
change pipelines flavor to payload to be in line with cmtools

### DIFF
--- a/examples/error_code_decisions.yaml
+++ b/examples/error_code_decisions.yaml
@@ -30,7 +30,7 @@ pandaErrorCode:
             ticket: ["DM-39196", "DM-38691", "DM-38360", "DM-37483", "DM-37089"]
             resolved: False
             rescue: False
-            flavor: "pipelines"
+            flavor: "payload"
             intensity: 0.001
         psfex:
             diagMessage: >
@@ -40,7 +40,7 @@ pandaErrorCode:
             ticket: ["DM-37570"]
             resolved: False
             rescue: False
-            flavor: "pipelines"
+            flavor: "payload"
             intensity: 0.001
         FWHM_value_of_nan:
             diagMessage: ".*PSF at (.*) has an invalid FWHM value of nan"
@@ -48,7 +48,7 @@ pandaErrorCode:
             ticket: ["DM-37089"]
             resolved: False
             rescue: False
-            flavor: "pipelines"
+            flavor: "payload"
             intensity: 0.001
         NaN_to_int_calibrate:
             diagMessage: ".*cannot convert float NaN to integer"
@@ -56,7 +56,7 @@ pandaErrorCode:
             ticket: ["DM-36356"]
             resolved: False
             rescue: False
-            flavor: "pipelines"
+            flavor: "payload"
             intensity: 0.001
         no_use_for_photocal:
             diagMessage: ".*No matches to use for photocal"
@@ -64,7 +64,7 @@ pandaErrorCode:
             ticket: ["DM-37483", "DM-37089", "DM-32291", "DM-36763"]
             resolved: False
             rescue: False
-            flavor: "pipelines"
+            flavor: "payload"
             intensity: 0.001
         NaN_to_int_detection:
             diagMessage: ".*cannot convert float NaN to integer"
@@ -72,7 +72,7 @@ pandaErrorCode:
             ticket: ["DM-36763", "DM-36356", "DM-36066"]
             resolved: False
             rescue: False
-            flavor: "pipelines"
+            flavor: "payload"
             intensity: 0.001
         all_pixels_masked:
             diagMessage: ".*All pixels masked. Cannot estimate background"
@@ -80,7 +80,7 @@ pandaErrorCode:
             ticket: ["DM-37837", "DM-37570"]
             resolved: True
             rescue: False
-            flavor: "pipelines"
+            flavor: "payload"
             intensity: 0
         too_many_indicies:
             diagMessage: ".*too many indices for array: array is 1-dimensional, but 2 were indexed"
@@ -88,7 +88,7 @@ pandaErrorCode:
             ticket: ["DM-37837", "DM-37570"]
             resolved: True
             rescue: False
-            flavor: "pipelines"
+            flavor: "payload"
             intensity: 0
         do_compute_kernel_image:
             diagMessage: >
@@ -98,7 +98,7 @@ pandaErrorCode:
             ticket: ["DM-37483", "DM-37089", "DM-36265", "DM-36356", "DM-36066"]
             resolved: False
             rescue: False
-            flavor: "pipelines"
+            flavor: "payload"
             intensity: 0.001
         kernel_candidacy:
             diagMessage: ".*Cannot find any objects suitable for KernelCandidacy"
@@ -108,7 +108,7 @@ pandaErrorCode:
                  "DM-36265", "DM-36356", "DM-36066"]
             resolved: False
             rescue: False
-            flavor: "pipelines"
+            flavor: "payload"
             intensity: 0.001
         psf_matching_kernel_subtractImages:
             diagMessage: ".*Unable to calculate psf matching kernel"
@@ -116,7 +116,7 @@ pandaErrorCode:
             ticket: ["DM-39196", "DM-38691", "DM-38360", "DM-38042", "DM-37570", "DM-37089"]
             resolved: False
             rescue: False
-            flavor: "pipelines"
+            flavor: "payload"
             intensity: 0.001
         array_sample_empty:
             diagMessage: ".*array of sample points is empty"
@@ -124,7 +124,7 @@ pandaErrorCode:
             ticket: ["DM-37570"]
             resolved: False
             rescue: False
-            flavor: "pipelines"
+            flavor: "payload"
             intensity: 0.001
         fp_xp:
             diagMessage: ".*fp and xp are not of the same length."
@@ -132,7 +132,7 @@ pandaErrorCode:
             ticket: ["DM-37570"]
             resolved: False
             rescue: False
-            flavor: "pipelines"
+            flavor: "payload"
             intensity: 0.001
         lmfit_mad:
             diagMessage: >
@@ -144,7 +144,7 @@ pandaErrorCode:
             ticket: ["DM-38691", "DM-38360"]
             resolved: False
             rescue: False
-            flavor: "pipelines"
+            flavor: "payload"
             intensity: 0.001
         parquet_formatter:
             diagMessage: >
@@ -154,7 +154,7 @@ pandaErrorCode:
             ticket: ["DM-36306", "DM-36356"]
             resolved: False
             rescue: False
-            flavor: "pipelines"
+            flavor: "payload"
             intensity: 0.001
         fgcm_380:
             diagMessage: ".*(380, 40)"
@@ -192,7 +192,7 @@ pandaErrorCode:
             ticket: ["DM-38360", "DM-37483", "DM-37089", "DM-36763", "DM-36356"]
             resolved: False
             rescue: False
-            flavor: "pipelines"
+            flavor: "payload"
             intensity: 0.001
         p_psf_matching_kernel:
             diagMessage: ".*ERROR: Unable to calculate psf matching kernel"
@@ -200,7 +200,7 @@ pandaErrorCode:
             ticket: ["DM-38691", "DM-38360", "DM-38042", "DM-37570", "DM-37483", "DM-36763", "DM-36356", "DM-36066"]
             resolved: False
             rescue: False
-            flavor: "pipelines"
+            flavor: "payload"
             intensity: 0.001
         psf_in_GAaP:
             diagMessage: >
@@ -210,7 +210,7 @@ pandaErrorCode:
             ticket: ["DM-38042", "DM-37483", "DM-33375", "DM-36763", "DM-36356"]
             resolved: False
             rescue: False
-            flavor: "pipelines"
+            flavor: "payload"
             intensity: 0.001
         p_psfex:
             diagMessage: ".*Only spatial variation (ndim == 2) is supported; saw 0"
@@ -218,7 +218,7 @@ pandaErrorCode:
             ticket: ["DM-37570"]
             resolved: False
             rescue: False
-            flavor: "pipelines"
+            flavor: "payload"
             intensity: 0.001
         p_no_use_for_photocal:
             diagMessage: >
@@ -228,7 +228,7 @@ pandaErrorCode:
             ticket: ["DM-37483", "DM-37089", "DM-32291", "DM-36763"]
             resolved: False
             rescue: False
-            flavor: "pipelines"
+            flavor: "payload"
             intensity: 0.001
         p_NaN_to_int_calibrate:
             diagMessage: >
@@ -238,7 +238,7 @@ pandaErrorCode:
             ticket: ["DM-36356"]
             resolved: False
             rescue: False
-            flavor: "pipelines"
+            flavor: "payload"
             intensity: 0.001
         p_FWHM_value_of_nan:
             diagMessage: >
@@ -248,7 +248,7 @@ pandaErrorCode:
             ticket: ["DM-37089", "DM-36763"]
             resolved: False
             rescue: False
-            flavor: "pipelines"
+            flavor: "payload"
             intensity: 0.001
         finalizeCharacterization_failed:
             diagMessage: >
@@ -328,7 +328,7 @@ pandaErrorCode:
             ticket: ["DM-37786", "DM-37570"]
             resolved: True
             rescue: False
-            flavor: "pipelines"
+            flavor: "payload"
             intensity: 0
         outside_image_bounds:
             diagMessage: >
@@ -338,7 +338,7 @@ pandaErrorCode:
             ticket: ["DM-35722", "DM-36066"]
             resolved: True
             rescue: False
-            flavor: "pipelines"
+            flavor: "payload"
             intensity: 0.001
         p_NaN_to_int_detection:
             diagMessage: >
@@ -348,7 +348,7 @@ pandaErrorCode:
             ticket: ["DM-36763", "DM-36356", "DM-36066"]
             resolved: False
             rescue: False
-            flavor: "pipelines"
+            flavor: "payload"
             intensity: 0.001
         p_all_pixels_masked:
             diagMessage: ".*All pixels masked. Cannot estimate background"
@@ -356,7 +356,7 @@ pandaErrorCode:
             ticket: ["DM-37570"]
             resolved: True
             rescue: False
-            flavor: "pipelines"
+            flavor: "payload"
             intensity: 0
         p_psf_matching_kernel_subtractImages:
             diagMessage: ".*ERROR: Unable to calculate psf matching kernel"
@@ -364,7 +364,7 @@ pandaErrorCode:
             ticket: ["DM-38042", "DM-37570", "DM-37483", "DM-37089", "DM-36265", "DM-36356", "DM-36066"]
             resolved: False
             rescue: False
-            flavor: "pipelines"
+            flavor: "payload"
             intensity: 0.001
         cannot_compute_coaddpsf:
             diagMessage: >
@@ -377,7 +377,7 @@ pandaErrorCode:
             ticket: ["DM-37570", "DM-37483", "DM-37089", "DM-36265", "DM-36356", "DM-36066"]
             resolved: False
             rescue: False
-            flavor: "pipelines"
+            flavor: "payload"
             intensity: 0.001
         p_kernel_candidacy:
             diagMessage: >
@@ -387,7 +387,7 @@ pandaErrorCode:
             ticket: ["DM-38360", "DM-38042", "DM-37570", "DM-37483", "DM-36265", "DM-36356", "DM-36066"]
             resolved: False
             rescue: False
-            flavor: "pipelines"
+            flavor: "payload"
             intensity: 0.001
         p_do_compute_kernel_image:
             diagMessage: >
@@ -397,7 +397,7 @@ pandaErrorCode:
             ticket: ["DM-37570", "DM-37483", "DM-36265", "DM-36356", "DM-36066"]
             resolved: False
             rescue: False
-            flavor: "pipelines"
+            flavor: "payload"
             intensity: 0.001
         kernel_does_not_exist:
             diagMessage: ".*Original kernel does not exist {0}.* Visiting candidate {1}{{}}"
@@ -405,7 +405,7 @@ pandaErrorCode:
             ticket: ["DM-38691", "DM-37570", "DM-37483", "DM-36265", "DM-36356", "DM-36066"]
             resolved: False
             rescue: False
-            flavor: "pipelines"
+            flavor: "payload"
             intensity: 0.001
         kernel_sum:
             diagMessage: ".*Unable to determine kernel sum; 0 candidates"
@@ -413,7 +413,7 @@ pandaErrorCode:
             ticket: ["DM-38360", "DM-38042", "DM-37483", "DM-36265", "DM-36356", "DM-36066"]
             resolved: False
             rescue: False
-            flavor: "pipelines"
+            flavor: "payload"
             intensity: 0.001
         p_NaN_to_int_subtractImages:
             diagMessage: ".*Exception ValueError: cannot convert float NaN to integer"
@@ -421,7 +421,7 @@ pandaErrorCode:
             ticket: ["DM-36265", "DM-36356", "DM-36066"]
             resolved: False
             rescue: False
-            flavor: "pipelines"
+            flavor: "payload"
             intensity: 0.001
         p_array_sample_empty:
             diagMessage: ".*array of sample points is empty"
@@ -429,7 +429,7 @@ pandaErrorCode:
             ticket: ["DM-37570"]
             resolved: False
             rescue: False
-            flavor: "pipelines"
+            flavor: "payload"
             intensity: 0.001
         p_fp_xp:
             diagMessage: ".*fp and xp are not of the same length."
@@ -437,7 +437,7 @@ pandaErrorCode:
             ticket: ["DM-37570"]
             resolved: False
             rescue: False
-            flavor: "pipelines"
+            flavor: "payload"
             intensity: 0.001
         u_psf:
             diagMessage: >
@@ -447,7 +447,7 @@ pandaErrorCode:
             ticket: ["DM-36305", "DM-36356"]
             resolved: False
             rescue: False
-            flavor: "pipelines"
+            flavor: "payload"
             intensity: 0.001
         p_remote_io:
             diagMessage: >
@@ -465,7 +465,7 @@ pandaErrorCode:
             ticket: ["DM-39092", "DM-38781", "DM-37822"]
             resolved: False
             rescue: False
-            flavor: "pipelines"
+            flavor: "payload"
             intensity: 0.001
     taskbuffer, 300:
         failed_while_starting_job:


### PR DESCRIPTION
cm_tools internally uses payload instead of pipelines, which is a little more accurate in terms of definition.

This discrepency was behind things falsely getting marked as rescueable.