### PR TITLE
DM-40478: Update CM tools config to use the right panda setup script(s)

### DIFF
--- a/src/lsst/cm/prod/configs/DC2/test/dc2_bps_template.sh
+++ b/src/lsst/cm/prod/configs/DC2/test/dc2_bps_template.sh
@@ -11,8 +11,8 @@ setup lsst_distrib
 
 # setup PanDA env.
 latest_panda=$(ls -td /cvmfs/sw.lsst.eu/linux-x86_64/panda_env/v* | head -1)
-setupScript=${latest_panda}/setup_panda_s3df.sh
-source $setupScript ${WEEKLY}
+source ${latest_panda}/setup_lsst.sh ${WEEKLY}
+source ${latest_panda}/setup_panda.sh
 
 env | grep PANDA
 

--- a/src/lsst/cm/prod/configs/HSC/test/hsc_bps_template.sh
+++ b/src/lsst/cm/prod/configs/HSC/test/hsc_bps_template.sh
@@ -11,8 +11,8 @@ setup lsst_distrib
 
 # setup PanDA env.
 latest_panda=$(ls -td /cvmfs/sw.lsst.eu/linux-x86_64/panda_env/v* | head -1)
-setupScript=${latest_panda}/setup_panda_s3df.sh
-source $setupScript ${WEEKLY}
+source ${latest_panda}/setup_lsst.sh ${WEEKLY}
+source ${latest_panda}/setup_panda.sh
 
 env | grep PANDA
 


### PR DESCRIPTION
Tested using RC2 mini. Successfully submitted, checked, over multiple steps. This is a quick fix, but we can implement setups that make it even easier to use the shared stack later if needed.