### PR TITLE
DM-42989: Add pipetaskOutput:  to avoid BPS collection chaining

### DIFF
--- a/src/lsst/cm/prod/configs/DC2/test/dc2_template.yaml
+++ b/src/lsst/cm/prod/configs/DC2/test/dc2_template.yaml
@@ -13,6 +13,8 @@ includeConfigs:
 
 custom_lsst_setup: ""
 
+pipetaskOutput: ""
+
 finalJob:
   command1: >-
     ${DAF_BUTLER_DIR}/bin/butler {finalPreCmdOpts} transfer-from-graph

--- a/src/lsst/cm/prod/configs/HSC/test/hsc_template.yaml
+++ b/src/lsst/cm/prod/configs/HSC/test/hsc_template.yaml
@@ -12,6 +12,8 @@ numberOfRetries: 3
 
 custom_lsst_setup: ""
 
+pipetaskOutput: ""
+
 finalJob:
   command1: >-
     ${DAF_BUTLER_DIR}/bin/butler {finalPreCmdOpts} transfer-from-graph
@@ -20,5 +22,3 @@ finalJob:
     --register-dataset-types
 
 priority: 1000
-
-pipetaskOutput: ''


### PR DESCRIPTION
In addition to the changes merged just before the DC2 w_2024_08, these were necessary to run the processing. They should be merged to main so that they do not have to be made again in order to use cm_prod.